### PR TITLE
rootユーザーを作成せずコンテナを利用できるようにする #8 

### DIFF
--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -17,6 +17,7 @@ services:
     depends_on:
       - db
   db:
+    build: ./db
     image: postgres:16.3
     volumes:
       - postgres_data:/var/lib/postgresql/data/

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,7 +11,7 @@ services:
       - ./.env
 
   db:
-    image: postgres:16.3
+    build: ./db
     volumes:
       # NOTE: volumesに関する記述を変えることで
       #       environmentに設定した値が反映されるようになった

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,0 +1,8 @@
+FROM postgres:16.3
+
+# 必要なロケールを生成
+RUN localedef -i ja_JP -c -f UTF-8 -A /usr/share/locale/locale.alias ja_JP.UTF-8
+
+ENV LANG ja_JP.utf8
+
+# rootユーザーでまずは操作できるようになった

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -6,4 +6,5 @@ RUN localedef -i ja_JP -c -f UTF-8 -A /usr/share/locale/locale.alias ja_JP.UTF-8
 ENV LANG ja_JP.utf8
 
 # 非rootユーザーで動かすためにpostgresユーザーを利用
+# FIXME: 他のユーザーを作成した方が良さそうなら修正する
 USER postgres

--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -5,4 +5,5 @@ RUN localedef -i ja_JP -c -f UTF-8 -A /usr/share/locale/locale.alias ja_JP.UTF-8
 
 ENV LANG ja_JP.utf8
 
-# rootユーザーでまずは操作できるようになった
+# 非rootユーザーで動かすためにpostgresユーザーを利用
+USER postgres


### PR DESCRIPTION
db側対応

`8-not-root-user-nginx`ブランチから`8-not-root-user-db`ブランチを切った。